### PR TITLE
Resolved shape broadcast error

### DIFF
--- a/mnist.py
+++ b/mnist.py
@@ -9,10 +9,14 @@ transform = transforms.Compose([transforms.ToTensor(),
                                                      (0.32780124, 0.32292358, 0.32056796)),
                                 ])
 
+transform_grayscale = transform = transforms.Compose([transforms.ToTensor(),
+                                transforms.Normalize((0.29730626,), (0.32780124,))
+                                ])
+
 mnist_train_dataset = datasets.MNIST(root='data/pytorch/MNIST', train=True, download=True,
                                      transform=transform)
 mnist_valid_dataset = datasets.MNIST(root='data/pytorch/MNIST', train=True, download=True,
-                                     transform=transforms)
+                                     transform=transform)
 mnist_test_dataset = datasets.MNIST(root='data/pytorch/MNIST', train=False, transform=transform)
 
 indices = list(range(len(mnist_train_dataset)))


### PR DESCRIPTION
Hi.

I ran the code you have in this repository and ran into an error documented [here](https://github.com/NaJaeMin92/pytorch_DANN/issues/3). I have found a solution for it, with comparable performance as reported.

- Here, I've added transform_grayscale, which is a single-channel transform
- This single-channel transform is used to transform 
```python
transform = transforms.Compose([transforms.ToTensor(),
                                transforms.Normalize((0.29730626, 0.29918741, 0.27534935),
                                                     (0.32780124, 0.32292358, 0.32056796)),
                                ])

transform_grayscale = transform = transforms.Compose([transforms.ToTensor(),
                                transforms.Normalize((0.29730626,), (0.32780124,))
                                ])

mnist_train_dataset = datasets.MNIST(root='data/pytorch/MNIST', train=True, download=True,
                                     transform=transform)
mnist_valid_dataset = datasets.MNIST(root='data/pytorch/MNIST', train=True, download=True,
                                     transform=transform)
mnist_test_dataset = datasets.MNIST(root='data/pytorch/MNIST', train=False, transform=transform)
````